### PR TITLE
Refactor: make this a python package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .idea
+__pycache__
+*.pyc
+*.egg-info
+.ipynb_checkpoints

--- a/README.md
+++ b/README.md
@@ -1,2 +1,43 @@
 # LSTMSeq2ML
-Code for learning how to train a LSTM 
+
+Code for learning how to train a LSTM
+
+# Command-line interface
+
+## Display most popular targets
+
+This will print the 25 most popular targets in the training set.
+
+```
+seq2ml popular --filepath ~/data/processed_ohdsi_sequences_20200111.hdf5
+```
+
+## Training
+
+The following code example trains a GRU model (named `gru_tiny`) to predict the `Evaluation finding` target. This uses the GPU device `0` as defined in `CUDA_VISIBLE_DEVICES`. To use multiple GPUs, prepend the `seq2ml train` call with `CUDA_VISIBLE_DEVICES=0,1`.
+
+```
+CUDA_VISIBLE_DEVICES=0 seq2ml train \
+    --filepath ~/data/processed_ohdsi_sequences_20200111.hdf5 \
+    --target-name "Evaluation finding" \
+    --model-name gru_tiny \
+    --learning-rate 0.001 \
+    --batch-size 48 \
+    --epochs 5 \
+    --save-history \
+    --evaluate
+```
+
+The following code example trains using a GRU model that does not use the fast cuDNN implementation of GRU. Notice that the training time is much longer than that of the cuDNN-compatible model.
+
+```
+CUDA_VISIBLE_DEVICES=0 seq2ml train \
+    --filepath ~/data/processed_ohdsi_sequences_20200111.hdf5 \
+    --target-name "Evaluation finding" \
+    --model-name gru_tiny_no_cudnn \
+    --learning-rate 0.001 \
+    --batch-size 48 \
+    --epochs 5 \
+    --save-history \
+    --evaluate
+```

--- a/seq2ml/cli.py
+++ b/seq2ml/cli.py
@@ -1,5 +1,6 @@
 """Command-line interface to train and evaulate models."""
 
+import json
 import os
 import pprint
 import sys
@@ -7,8 +8,21 @@ import sys
 import click
 import h5py
 import sklearn.metrics
+import tensorflow as tf
 
 from .models import get_model
+
+tfk = tf.keras
+
+
+class JSONParamType(click.ParamType):
+    name = "json"
+
+    def convert(self, value, param, ctx):
+        try:
+            return json.loads(value)
+        except json.decoder.JSONDecodeError:
+            self.fail("%s is not valid JSON" % value, param, ctx)
 
 
 @click.group()
@@ -23,6 +37,8 @@ def popular(*, filepath, n_cut):
     """Print the most popular labels in the dataset."""
 
     with h5py.File(filepath, mode="r") as f:
+        x_train_len = f["/data/processed/train/sequence/core_array"].shape[0]
+        y_train_all = f["/data/processed/train/target/core_array"][:]
         y_train_labels = f["/data/processed/train/target/column_annotations"][:]
 
     # Count the occurrence of the labels in the training set, and display the most
@@ -30,8 +46,9 @@ def popular(*, filepath, n_cut):
     target_labels = [str(s, "utf-8") for s in y_train_labels.flatten().tolist()]
     sum_targets = y_train_all.sum(0).tolist()
     sum_target_with_labels = [
-        (target_labels[i].split("|")[-1], sum_targets[i], sum_targets[i] / x_train.shape[0])
-        for i, _ in enumerate(target_labels)]
+        (target_labels[i].split("|")[-1], sum_targets[i], sum_targets[i] / x_train_len)
+        for i, _ in enumerate(target_labels)
+    ]
     sum_target_with_labels.sort(key=lambda x: -1 * x[1])
 
     print("The top {} variables in the training set.".format(n_cut))
@@ -46,16 +63,30 @@ def popular(*, filepath, n_cut):
 @cli.command()
 @click.option("--filepath", "-f", type=click.Path(exists=True), required=True)
 @click.option("--target-name", "-t", required=True)
+@click.option("--model-name", "-m", required=True)
 @click.option("--batch-size", "-b", default=48, show_default=True)
 @click.option("--epochs", "-e", default=1, show_default=True)
 @click.option("--learning-rate", "-l", default=1e-3, show_default=True)
 @click.option("--evaluate/--no-evaluate", default=True, show_default=True)
-def train(*, filepath, target_name, model_name, batch_size, epochs, learning_rate):
+@click.option("--model-kwds", type=JSONParamType(), show_default=True)
+def train(
+    *,
+    filepath,
+    target_name,
+    model_name,
+    batch_size,
+    epochs,
+    learning_rate,
+    evaluate,
+    model_kwds
+):
+    """Train an recurrent network."""
 
-    print("\Training to predict '{}'.".format(target_name), flush=True)
+    print("Training to predict '{}'.".format(target_name), flush=True)
 
     # Try to get the model first so if it is not available, we error quickly.
-    model = get_model(model_name)
+    model_fn = get_model(model_name)
+    model = model_fn() if model_kwds is None else model_fn(**model_kwds)
 
     # Find the target index for the labels.
     with h5py.File(filepath, mode="r") as f:
@@ -79,26 +110,29 @@ def train(*, filepath, target_name, model_name, batch_size, epochs, learning_rat
         metrics=["accuracy"],
     )
 
+    target_name_label = "_".join(target_name.lower().split())
+
+    # TODO: add callbacks
     callbacks = []
 
-    history = model.train(
+    history = model.fit(
         x=x_train,
         y=y_train,
         epochs=epochs,
         batch_size=batch_size,
-        validation_data=(x_test, y_test),
+        # validation_data=(x_test, y_test),
         callbacks=callbacks,
     )
 
     if evaluate:
-        y_pred = model.predict(x_test, verbose=1).ravel()
+        y_pred = model.predict(x_test).ravel()
         y_pred = tf.sigmoid(y_pred).numpy()
-        y_pred_classes = y_pred.argmax(-1)
+
+        threshold = 0.5
+        y_pred_classes = (y_pred > threshold).astype("int32")
 
         results_dict = {
-            "meta": {
-                "python_program": os.path.abspath(__file__)
-            },
+            "meta": {"python_program": os.path.abspath(__file__)},
             "model": {
                 "learning_rate": learning_rate,
                 "batch_size": batch_size,
@@ -106,10 +140,10 @@ def train(*, filepath, target_name, model_name, batch_size, epochs, learning_rat
             },
             "target": {
                 "target_name": target_name,
-                "target_name_label": target_name_label
+                "target_name_label": target_name_label,
             },
             "data": {
-                "input_filename": data_path,
+                "input_filename": filepath,
                 "training_size_n": x_train.shape[0],
                 "max_time_steps_n": x_train.shape[1],
                 "features_n": x_train.shape[2],
@@ -121,9 +155,13 @@ def train(*, filepath, target_name, model_name, batch_size, epochs, learning_rat
                 "sum_of_probabilities_test_set": y_pred.sum(),
                 "model_auc_score": sklearn.metrics.roc_auc_score(y_test, y_pred),
                 "f1_score": sklearn.metrics.f1_score(y_pred_classes, y_test),
-                "average_precision_recall": sklearn.metrics.average_precision_score(y_pred_classes, y_test),
-                "classification_report": sklearn.metrics.classification_report(y_pred_classes, y_test),
-            }
+                "average_precision_recall": sklearn.metrics.average_precision_score(
+                    y_pred_classes, y_test
+                ),
+                "classification_report": sklearn.metrics.classification_report(
+                    y_pred_classes, y_test
+                ),
+            },
         }
 
         pprint.pprint(results_dict)

--- a/seq2ml/cli.py
+++ b/seq2ml/cli.py
@@ -1,0 +1,131 @@
+"""Command-line interface to train and evaulate models."""
+
+import os
+import pprint
+import sys
+
+import click
+import h5py
+import sklearn.metrics
+
+from .models import get_model
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command()
+@click.option("--filepath", "-f", type=click.Path(exists=True), required=True)
+@click.option("--n-cut", "-n", type=int, required=True, default=25)
+def popular(*, filepath, n_cut):
+    """Print the most popular labels in the dataset."""
+
+    with h5py.File(filepath, mode="r") as f:
+        y_train_labels = f["/data/processed/train/target/column_annotations"][:]
+
+    # Count the occurrence of the labels in the training set, and display the most
+    # common ones.
+    target_labels = [str(s, "utf-8") for s in y_train_labels.flatten().tolist()]
+    sum_targets = y_train_all.sum(0).tolist()
+    sum_target_with_labels = [
+        (target_labels[i].split("|")[-1], sum_targets[i], sum_targets[i] / x_train.shape[0])
+        for i, _ in enumerate(target_labels)]
+    sum_target_with_labels.sort(key=lambda x: -1 * x[1])
+
+    print("The top {} variables in the training set.".format(n_cut))
+    _s = "{:<45} {:>10} {:>10}".format("Label", "N", "Ratio")
+    print()
+    print(_s)
+    print("-" * len(_s))
+    for row in sum_target_with_labels[:n_cut]:
+        print("{:<45} {:>10} {:>10.3f}".format(*row))
+
+
+@cli.command()
+@click.option("--filepath", "-f", type=click.Path(exists=True), required=True)
+@click.option("--target-name", "-t", required=True)
+@click.option("--batch-size", "-b", default=48, show_default=True)
+@click.option("--epochs", "-e", default=1, show_default=True)
+@click.option("--learning-rate", "-l", default=1e-3, show_default=True)
+@click.option("--evaluate/--no-evaluate", default=True, show_default=True)
+def train(*, filepath, target_name, model_name, batch_size, epochs, learning_rate):
+
+    print("\Training to predict '{}'.".format(target_name), flush=True)
+
+    # Try to get the model first so if it is not available, we error quickly.
+    model = get_model(model_name)
+
+    # Find the target index for the labels.
+    with h5py.File(filepath, mode="r") as f:
+        y_train_labels = f["/data/processed/train/target/column_annotations"][:]
+
+    target_prefix = "static_condition_hierarchy_condition_concept_name|"
+    target_index_name = target_prefix + target_name
+    target_labels = [str(s, "utf-8") for s in y_train_labels.flatten().tolist()]
+    target_index = target_labels.index(target_index_name)
+
+    # Load train/test data.
+    with h5py.File(filepath, mode="r") as f:
+        x_train = f["/data/processed/train/sequence/core_array"][:]
+        y_train = f["/data/processed/train/target/core_array"][:, target_index]
+        x_test = f["/data/processed/test/sequence/core_array"][:]
+        y_test = f["/data/processed/test/target/core_array"][:, target_index]
+
+    model.compile(
+        loss=tfk.losses.BinaryCrossentropy(from_logits=True),
+        optimizer=tfk.optimizers.Adam(learning_rate),
+        metrics=["accuracy"],
+    )
+
+    callbacks = []
+
+    history = model.train(
+        x=x_train,
+        y=y_train,
+        epochs=epochs,
+        batch_size=batch_size,
+        validation_data=(x_test, y_test),
+        callbacks=callbacks,
+    )
+
+    if evaluate:
+        y_pred = model.predict(x_test, verbose=1).ravel()
+        y_pred = tf.sigmoid(y_pred).numpy()
+        y_pred_classes = y_pred.argmax(-1)
+
+        results_dict = {
+            "meta": {
+                "python_program": os.path.abspath(__file__)
+            },
+            "model": {
+                "learning_rate": learning_rate,
+                "batch_size": batch_size,
+                "epochs": epochs,
+            },
+            "target": {
+                "target_name": target_name,
+                "target_name_label": target_name_label
+            },
+            "data": {
+                "input_filename": data_path,
+                "training_size_n": x_train.shape[0],
+                "max_time_steps_n": x_train.shape[1],
+                "features_n": x_train.shape[2],
+                "total_positive_cases_training_set": y_train.sum(),
+            },
+            "test": {
+                "total_positive_cases_test_set": y_test.sum(),
+                "sum_predicted_test_set": y_pred_classes.sum(),
+                "sum_of_probabilities_test_set": y_pred.sum(),
+                "model_auc_score": sklearn.metrics.roc_auc_score(y_test, y_pred),
+                "f1_score": sklearn.metrics.f1_score(y_pred_classes, y_test),
+                "average_precision_recall": sklearn.metrics.average_precision_score(y_pred_classes, y_test),
+                "classification_report": sklearn.metrics.classification_report(y_pred_classes, y_test),
+            }
+        }
+
+        pprint.pprint(results_dict)
+
+        # TODO: save results to JSON.

--- a/seq2ml/models.py
+++ b/seq2ml/models.py
@@ -23,6 +23,7 @@ import tensorflow as tf
 tfk = tf.keras
 tfkl = tfk.layers
 
+
 def get_model(name):
     d = {
         "gru_v1": gru_v1,
@@ -32,7 +33,10 @@ def get_model(name):
         return d[name]
     except KeyError:
         raise ValueError(
-            "unknown model name: '{}'. Available models: '{}'".format(name, "', '".join(model.keys())))
+            "unknown model name: '{}'. Available models: '{}'".format(
+                name, "', '".join(model.keys())
+            )
+        )
 
 
 def gru_v1(input_shape=(200, 692), dropout_rate=0.5):
@@ -83,7 +87,7 @@ def gru_tiny(input_shape=(200, 692), dropout_rate=0.5):
     model = tfk.Sequential()
     model.add(tfkl.Input(input_shape))
     model.add(tfkl.Masking(mask_value=0.0))
-    model.add(tfkl.GRU(128, return_sequences=True))
+    model.add(tfkl.GRU(128))
     model.add(tfkl.Dropout(dropout_rate))
     model.add(tfkl.Dense(1))
     return model

--- a/seq2ml/models.py
+++ b/seq2ml/models.py
@@ -1,0 +1,89 @@
+"""Model definitions.
+
+To use the fast cuDNN GRU implementation, the following conditions must be met:
+    1. activation == tanh
+    2. recurrent_activation == sigmoid
+    3. recurrent_dropout == 0
+    4. unroll is False
+    5. use_bias is True
+    6. reset_after is True
+    7. Inputs are not masked or are strictly right padded
+
+
+According to the TensorFlow documentation:
+    "[cuDNN cannot be used when] Using masking when the input data is not
+    strictly right padded (if the mask corresponds to strictly right padded data,
+    CuDNN can still be used. This is the most common case)."
+https://www.tensorflow.org/guide/keras/rnn#performance_optimization_and_cudnn_kernels_in_tensorflow_20
+
+"""
+
+import tensorflow as tf
+
+tfk = tf.keras
+tfkl = tfk.layers
+
+def get_model(name):
+    d = {
+        "gru_v1": gru_v1,
+        "gru_tiny": gru_tiny,
+    }
+    try:
+        return d[name]
+    except KeyError:
+        raise ValueError(
+            "unknown model name: '{}'. Available models: '{}'".format(name, "', '".join(model.keys())))
+
+
+def gru_v1(input_shape=(200, 692), dropout_rate=0.5):
+    """
+    Return GRU RNN compatible with fast cuDNN GRU implementation.
+    Variable-length sequences are allowed, but all sequences must have same size in the
+    last dimension.
+
+    Parameters
+    ----------
+    input_shape: int, the shape of input, excluding batch dimension.
+    dropout_rate: float in [0, 1], the rate of dropping connections.
+
+    Returns
+    -------
+    Tensorflow Keras model object.
+    """
+
+    model = tfk.Sequential()
+    model.add(tfkl.Input(input_shape))
+    model.add(tfkl.Masking(mask_value=0.0))
+    model.add(tfkl.GRU(256, return_sequences=True))
+    model.add(tfkl.Dropout(dropout_rate))
+    model.add(tfkl.GRU(256))
+    model.add(tfkl.Dropout(dropout_rate))
+    model.add(tfkl.Dense(128, activation="relu"))
+    model.add(tfkl.Dropout(dropout_rate))
+    model.add(tfkl.Dense(1))
+    return model
+
+
+def gru_tiny(input_shape=(200, 692), dropout_rate=0.5):
+    """
+    Return GRU RNN compatible with fast cuDNN GRU implementation.
+    Variable-length sequences are allowed, but all sequences must have same size in the
+    last dimension.
+
+    Parameters
+    ----------
+    input_shape: int, the shape of input, excluding batch dimension.
+    dropout_rate: float in [0, 1], the rate of dropping connections.
+
+    Returns
+    -------
+    Tensorflow Keras model object.
+    """
+
+    model = tfk.Sequential()
+    model.add(tfkl.Input(input_shape))
+    model.add(tfkl.Masking(mask_value=0.0))
+    model.add(tfkl.GRU(128, return_sequences=True))
+    model.add(tfkl.Dropout(dropout_rate))
+    model.add(tfkl.Dense(1))
+    return model

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,47 @@
+[metadata]
+name = seq2ml
+url = https://github.com/jhajagos/LSTMSeq2ML
+author = Seq2ML Developers
+classifiers =
+    Development Status :: 4 - Beta
+    Environment :: Console
+    Intended Audience :: Science/Research
+    # License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Topic :: Scientific/Engineering
+# license = MIT License
+description = Neural network models for clinical sequences
+long_description = file:README.md
+platforms = OS Independent
+
+[options]
+python_requires = >=3.6
+install_requires =
+    click
+    h5py
+    scikit-learn
+packages = find:
+
+[options.extras_require]
+dev =
+    black
+    flake8
+test =
+    pytest
+all =
+    %(dev)s
+    %(test)s
+
+[options.entry_points]
+console_scripts =
+    seq2ml=seq2ml.cli:cli
+
+[flake8]
+max-line-length = 100
+exclude =
+    *test*
+    */__init__.py

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,4 @@
+from setuptools import setup
+
+if __name__ == "__main__":
+    setup()


### PR DESCRIPTION
Hi @jhajagos - this pull request proposes making lstmseq2ml a python package. This organizes the code and provides an installable command-line tool (`seq2ml`).

I added info on how to use the package to the readme.

Here is how one would get the most popular targets in the hdf5 file.
```
seq2ml popular --filepath ~/data/processed_ohdsi_sequences_20200111.hdf5
```

And here is how one would train from the command-line.

```
CUDA_VISIBLE_DEVICES=0 seq2ml train \
    --filepath ~/data/processed_ohdsi_sequences_20200111.hdf5 \
    --target-name "Evaluation finding" \
    --model-name gru_tiny \
    --learning-rate 0.001 \
    --batch-size 48 \
    --epochs 5 \
    --save-history \
    --evaluate
```

You can also compare the training speed of the above to the following to see the difference the cuDNN implementation of GRU. The difference in both commands is the `--model-name`.

```
CUDA_VISIBLE_DEVICES=0 seq2ml train \
    --filepath ~/data/processed_ohdsi_sequences_20200111.hdf5 \
    --target-name "Evaluation finding" \
    --model-name gru_tiny_no_cudnn \
    --learning-rate 0.001 \
    --batch-size 48 \
    --epochs 5 \
    --save-history \
    --evaluate
```

The package can be installed with `python -m pip install --no-cache-dir --editable .` Tensorflow must be installed separately.